### PR TITLE
Only send new tests to Litmus since their API no longer supports versions.

### DIFF
--- a/lib/litmus.js
+++ b/lib/litmus.js
@@ -249,7 +249,7 @@ Litmus.prototype.getId = function(body) {
 };
 
 /**
-* Send a new version if id is availabe otherwise send a new test
+* Send a new test
 *
 * @param {Object} data - object map that contains the id passed
 *
@@ -261,17 +261,10 @@ Litmus.prototype.sendTest = function(data) {
 
   var body = this.getBuiltXml(this.html, this.title);
 
-  if (data.id) {
-    logger.info('Sending new version: ' + this.title);
-    return this.api.createVersion(data.id)
-      .bind(this)
-      .then(this.mailNewVersion);
-  } else {
-    logger.info('Sending new test: ' + this.title);
-    return this.api.createEmailTest(body)
-      .bind(this)
-      .then(this.logHeaders);
-  }
+  logger.info('Sending new test: ' + this.title);
+  return this.api.createEmailTest(body)
+    .bind(this)
+    .then(this.logHeaders);
 };
 
 /**


### PR DESCRIPTION
Removed the `if` statement making it so that a brand new test is sent each time rather than trying to send a new version and hanging.
