### PR TITLE
Lock version of `event-stream` to 3.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "cheerio": "^0.20.0",
     "cli-table": "^0.3.1",
     "dateformat": "^1.0.11",
-    "event-stream": "^3.3.0",
+    "event-stream": "3.3.4",
     "is-html": "^1.0.0",
     "juice": "^2.0.0",
     "litmus-api": "^0.3.2",


### PR DESCRIPTION
There is an ongoing issue with [event-stream ](https://blog.npmjs.org/post/180565383195/details-about-the-event-stream-incident)since a malicious person took over, see:
- https://github.com/dominictarr/event-stream/issues/115
- https://github.com/dominictarr/event-stream/issues/116

Either way, this locks to a known good version.

PS. Guys please create package-lock and perform npm audit. 